### PR TITLE
feat: Add API routes for disabling draft mode, enabling draft mode, a…

### DIFF
--- a/apps/frontend/src/app/api/disable-draft/route.ts
+++ b/apps/frontend/src/app/api/disable-draft/route.ts
@@ -1,0 +1,8 @@
+import { SERVER_SITE_URL } from "@kduprey/config";
+import { draftMode } from "next/headers";
+import { NextResponse } from "next/server";
+
+export function GET() {
+  draftMode().disable();
+  return NextResponse.redirect(new URL("/", SERVER_SITE_URL));
+}

--- a/apps/frontend/src/app/api/draft/route.ts
+++ b/apps/frontend/src/app/api/draft/route.ts
@@ -1,0 +1,21 @@
+// ./app/api/draft/route.ts
+
+import { validatePreviewUrl } from "@sanity/preview-url-secret";
+import { draftMode } from "next/headers";
+import { redirect } from "next/navigation";
+import { client, token } from "@/sanity";
+
+const clientWithToken = client.withConfig({ token });
+
+export async function GET(request: Request) {
+  const { isValid, redirectTo = "/" } = await validatePreviewUrl(
+    clientWithToken,
+    request.url,
+  );
+
+  if (!isValid) return new Response("Invalid secret", { status: 401 });
+
+  draftMode().enable();
+
+  redirect(redirectTo);
+}

--- a/apps/frontend/src/app/api/revalidate/route.ts
+++ b/apps/frontend/src/app/api/revalidate/route.ts
@@ -1,0 +1,39 @@
+import { revalidateTag } from "next/cache";
+import { type NextRequest, NextResponse } from "next/server";
+import { parseBody } from "next-sanity/webhook";
+
+interface WebhookPayload {
+  _type: string;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { body, isValidSignature } = await parseBody<WebhookPayload>(
+      req,
+      process.env.SANITY_REVALIDATE_SECRET,
+    );
+
+    if (!isValidSignature) {
+      const message = "Invalid signature";
+      return new Response(JSON.stringify({ body, isValidSignature, message }), {
+        status: 401,
+      });
+    }
+
+    if (!body?._type) {
+      const message = "Bad Request";
+      return new Response(JSON.stringify({ body, message }), { status: 400 });
+    }
+
+    // If the `_type` is `page`, then all `client.fetch` calls with
+    // `{next: {tags: ['page']}}` will be revalidated
+    revalidateTag(body._type);
+
+    return NextResponse.json({ body });
+  } catch (err) {
+    console.error(err);
+    return new Response(JSON.stringify({ message: "Internal Server Error" }), {
+      status: 500,
+    });
+  }
+}


### PR DESCRIPTION
…nd revalidating cache

This commit adds three new API routes for managing draft mode and cache revalidation. The `disable-draft` route disables draft mode and redirects to the home page. The `draft` route enables draft mode and redirects to the preview URL. The `revalidate` route receives a webhook payload, validates the signature, and revalidates the cache based on the payload type. These changes enhance the functionality of the application and improve the developer experience.