### PR TITLE
chore: Update cut-minor-release.yml and cut-patch-release.yml workflows

### DIFF
--- a/.github/workflows/cut-minor-release.yml
+++ b/.github/workflows/cut-minor-release.yml
@@ -1,7 +1,8 @@
 name: Cut Minor Release
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - main
 
@@ -9,7 +10,7 @@ on:
 
 jobs:
   cutMinorRelease:
-    if: github.actor == 'kduprey' && !contains(github.event.head_commit.message, 'hotfix')
+    if: github.actor == 'kduprey' && github.event.pull_request.merged == true && !contains(github.event.pull_request.head.ref, 'hotfix') && !contains(github.event.pull_request.labels.*.name, 'major version')
     runs-on: ubuntu-latest
     name: Cut Minor Release
     steps:

--- a/.github/workflows/cut-patch-release.yml
+++ b/.github/workflows/cut-patch-release.yml
@@ -1,7 +1,8 @@
 name: Cut Patch Release
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - main
 
@@ -11,7 +12,7 @@ permissions: write-all
 
 jobs:
   cutPatchRelease:
-    if: github.actor == 'dependabot[bot]' || github.actor == 'github-actions[bot]' || github.actor == 'kduprey-app-token[bot]' || contains(github.event.head_commit.message, 'hotfix')
+    if: github.actor == 'dependabot[bot]' || github.actor == 'github-actions' || contains(github.event.pull_request.head.ref, 'hotfix') && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     name: Cut Patch Release
     outputs:


### PR DESCRIPTION
This commit updates the cut-minor-release.yml and cut-patch-release.yml workflows. The changes include:
- Changing the trigger from push to pull_request with types: [closed]
- Adding conditions to the cutMinorRelease and cutPatchRelease jobs based on the actor, pull request merge status, and labels